### PR TITLE
Fixed State locked when asking for permissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
+
+# Description
+
+*Add a description of your PR, explaining what it does, what problem it solves (if any).*
+
+# Issues
+
+*Add `- fixes #XX` to automatically close the issue this PR adresses when merging into the default branch*.
+
+*Simply add `- #XX` to mention a linked issue.*.
+
+# Additional information
+
+*Add additional information (how to test, discussions and context that lead to this PR, etc.).*

--- a/lib/core/permission_handler.dart
+++ b/lib/core/permission_handler.dart
@@ -1,29 +1,38 @@
+// Global imports
 import 'dart:io';
 
+// Local imports
 import 'package:permission_handler/permission_handler.dart';
+
 
 class BluetoothPermissionHandler {
   static Future<bool> checkAndRequestPermissions() async {
-
-    // For Android 12+ we need both bluetooth scan and location permissions
     if (Platform.isAndroid) {
       final bluetoothScan = await Permission.bluetoothScan.status;
-      final bluetoothConnect = await Permission.bluetoothConnect.status;
-      final location = await Permission.locationWhenInUse.status;
-
-      if (!bluetoothScan.isGranted || !bluetoothConnect.isGranted || !location.isGranted) {
-        final results = await Future.wait([
-          Permission.bluetoothScan.request(),
-          Permission.bluetoothConnect.request(),
-          Permission.locationWhenInUse.request(),
-        ]);
-
-        return results.every((status) => status.isGranted);
+      if (!bluetoothScan.isGranted) {
+        final scanResult = await Permission.bluetoothScan.request();
+        if (!scanResult.isGranted) {
+          return false;
+        }
       }
+
+      final bluetoothConnect = await Permission.bluetoothConnect.status;
+      if (!bluetoothConnect.isGranted) {
+        final connectResult = await Permission.bluetoothConnect.request();
+        if (!connectResult.isGranted) {
+          return false;
+        }
+      }
+
+      final location = await Permission.locationWhenInUse.status;
+      if (!location.isGranted) {
+        final locationResult = await Permission.locationWhenInUse.request();
+        return locationResult.isGranted;
+      }
+
       return true;
     }
 
-    // For iOS we need bluetooth permission
     if (Platform.isIOS) {
       final bluetooth = await Permission.bluetooth.status;
       if (!bluetooth.isGranted) {
@@ -32,6 +41,26 @@ class BluetoothPermissionHandler {
       }
       return true;
     }
+
+    return false;
+  }
+
+  static Future<bool> arePermissionsGranted() async {
+    if (Platform.isAndroid) {
+      final bluetoothScan = await Permission.bluetoothScan.status;
+      final bluetoothConnect = await Permission.bluetoothConnect.status;
+      final location = await Permission.locationWhenInUse.status;
+
+      return bluetoothScan.isGranted &&
+             bluetoothConnect.isGranted &&
+             location.isGranted;
+    }
+
+    if (Platform.isIOS) {
+      final bluetooth = await Permission.bluetooth.status;
+      return bluetooth.isGranted;
+    }
+
     return false;
   }
 }

--- a/lib/data/repositories/bluetooth_repository_impl.dart
+++ b/lib/data/repositories/bluetooth_repository_impl.dart
@@ -10,12 +10,15 @@ import 'package:interview_flutter_fogo/data/models/bluetooth_device_model.dart';
 class BluetoothRepositoryImpl implements BluetoothRepository {
   @override
   Stream<List<BluetoothDeviceModel>> scanDevices() async* {
-    final hasPermissions = await BluetoothPermissionHandler.checkAndRequestPermissions();
-    if (!hasPermissions) {
-      throw BluetoothPermissionException('Bluetooth permissions not granted');
+    final permissionsGranted = await BluetoothPermissionHandler.arePermissionsGranted();
+
+    if (!permissionsGranted) {
+      final permissionsRequested = await BluetoothPermissionHandler.checkAndRequestPermissions();
+      if (!permissionsRequested) {
+        throw BluetoothPermissionException('Bluetooth permissions not granted');
+      }
     }
 
-    // Check if Bluetooth is turned on
     if (await FlutterBluePlus.adapterState.first == BluetoothAdapterState.off) {
       throw BluetoothDisabledException('Bluetooth is turned off');
     }


### PR DESCRIPTION
# Description

Fixes Bluetooth permission handling issues on Xiaomi devices by implementing sequential permission requests. The current implementation using `Future.wait()` causes the app to get stuck in a permission request state.
Since this is the first PR, I also added the PR template.

This PR:

- Implements sequential permission requests (Bluetooth scan ⇾ Bluetooth connect ⇾ Location)
- Adds immediate failure handling if any permission is denied
- Introduces a new `arePermissionsGranted()` method for better permission state management
- Add `.github/pull_request_template.md`

# Issues
- Fixes #1 

# Additional information
## Testing
1. Test on Xiaomi Redmi Note 11 Pro+
2. Verify permission flow:
   - Bluetooth scan permission request
   - Bluetooth connect permission request
   - Location permission request
3. Verify app behavior when:
   - All permissions are granted
   - Any permission is denied
   - Permissions were previously granted

## Device compatibility
Tested on:
- Xiaomi Redmi Note 11 Pro+ (Android 13)